### PR TITLE
Change 'absolte' in line 56 to 'absolute'

### DIFF
--- a/src/StarRatingComponent.jsx
+++ b/src/StarRatingComponent.jsx
@@ -53,7 +53,7 @@ class StarRatingComponent extends Component {
         };
         const radioStyles = {
             display: 'none',
-            position: 'absolte',
+            position: 'absolute',
             marginLeft: -9999
         };
 


### PR DESCRIPTION
Simple fix for a typo in line 56 of StarRatingComponent.jsx